### PR TITLE
configure relocation/shading to support usage with Hadoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,36 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.4.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.ning:*</include>
+                  <include>io.netty:*</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.ning.http</pattern>
+                  <shadedPattern>asyncclient.shaded.com.ning.http</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.jboss.netty</pattern>
+                  <shadedPattern>asyncclient.shaded.org.jboss.netty</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Hadoop uses com.ning:async-http-client and io.netty:netty versions that
are not compatible with the ones used by this client. That means that
it's not possible to use this client when writing to HDFS.