### PR TITLE
Use automatter 0.13.3 for compatibility with Jackson 2.8+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,18 +67,18 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>18.0</version>
+      <version>19.0</version>
     </dependency>
     <dependency>
       <groupId>io.norberg</groupId>
       <artifactId>auto-matter</artifactId>
-      <version>0.13.0</version>
+      <version>0.13.3</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>io.norberg</groupId>
       <artifactId>auto-matter-jackson</artifactId>
-      <version>0.13.0</version>
+      <version>0.13.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Also bump guava to 19.0 so enforcer plugin doesn't complain