### PR TITLE
Fixing compatibility with pubsub emulator

### DIFF
--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
@@ -136,7 +136,7 @@ public class Pubsub implements Closeable {
 
     final SSLSocketFactory sslSocketFactory =
         new ConfigurableSSLSocketFactory(config.getEnabledCipherSuites(),
-                                         (SSLSocketFactory) SSLSocketFactory.getDefault());
+            (SSLSocketFactory) SSLSocketFactory.getDefault());
 
     this.transport = new NetHttpTransport.Builder()
         .setSslSocketFactory(sslSocketFactory)
@@ -285,7 +285,7 @@ public class Pubsub implements Closeable {
   private PubsubFuture<Topic> createTopic(final String canonicalTopic,
                                           final Topic req) {
     validateCanonicalTopic(canonicalTopic);
-    return put("create topic", canonicalTopic, req, Topic.class);
+    return put("create topic", canonicalTopic, NO_PAYLOAD, Topic.class);
   }
 
   /**
@@ -410,7 +410,7 @@ public class Pubsub implements Closeable {
   private PubsubFuture<Subscription> createSubscription(final String canonicalSubscriptionName,
                                                         final Subscription subscription) {
     validateCanonicalSubscription(canonicalSubscriptionName);
-    return put("create subscription", canonicalSubscriptionName, subscription, Subscription.class);
+    return put("create subscription", canonicalSubscriptionName, subscription.toRequest(), Subscription.class);
   }
 
   /**

--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
@@ -271,19 +271,7 @@ public class Pubsub implements Closeable {
    * @param canonicalTopic The canonical (including project) name of the topic to create.
    * @return A future that is completed when this request is completed.
    */
-  public PubsubFuture<Topic> createTopic(final String canonicalTopic) {
-    return createTopic(canonicalTopic, Topic.of(canonicalTopic));
-  }
-
-  /**
-   * Create a Pub/Sub topic.
-   *
-   * @param canonicalTopic The canonical (including project) name of the topic to create.
-   * @param req            The payload of the create request. This seems to be ignore in the current API version.
-   * @return A future that is completed when this request is completed.
-   */
-  private PubsubFuture<Topic> createTopic(final String canonicalTopic,
-                                          final Topic req) {
+  private PubsubFuture<Topic> createTopic(final String canonicalTopic) {
     validateCanonicalTopic(canonicalTopic);
     return put("create topic", canonicalTopic, NO_PAYLOAD, Topic.class);
   }
@@ -760,6 +748,7 @@ public class Pubsub implements Closeable {
       builder.setHeader(CONTENT_TYPE, APPLICATION_JSON_UTF8);
       builder.setBody(json);
     } else {
+      builder.setHeader(CONTENT_LENGTH, String.valueOf(0));
       payloadSize = 0;
     }
 

--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Subscription.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Subscription.java
@@ -16,15 +16,14 @@
 
 package com.spotify.google.cloud.pubsub.client;
 
-import java.util.Optional;
-import java.util.regex.Pattern;
-
-import io.norberg.automatter.AutoMatter;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.spotify.google.cloud.pubsub.client.Topic.canonicalTopic;
 import static com.spotify.google.cloud.pubsub.client.Topic.validateCanonicalTopic;
+
+import io.norberg.automatter.AutoMatter;
+import java.util.Optional;
+import java.util.regex.Pattern;
 
 @AutoMatter
 public interface Subscription {
@@ -59,12 +58,19 @@ public interface Subscription {
   static String canonicalSubscription(final String project, final String subscription) {
     checkArgument(!isNullOrEmpty(project) && !project.contains("/"), "illegal project: %s", project);
     checkArgument(!isNullOrEmpty(subscription) && !subscription.contains("/") && !subscription.startsWith("goog"),
-                  "illegal subscription: %s", subscription);
+        "illegal subscription: %s", subscription);
     return PROJECTS + '/' + project + '/' + SUBSCRIPTIONS + '/' + subscription;
   }
 
   static void validateCanonicalSubscription(final String canonicalSubscription) {
     checkArgument(PATTERN.matcher(canonicalSubscription).matches(), "malformed subscription: %s",
-                  canonicalSubscription);
+        canonicalSubscription);
   }
+
+  default SubscriptionCreateRequest toRequest() {
+    return new SubscriptionCreateRequestBuilder().topic(topic()).pushConfig(pushConfig()).ackDeadlineSeconds(ackDeadlineSeconds()).build();
+  }
+
+
 }
+

--- a/src/main/java/com/spotify/google/cloud/pubsub/client/SubscriptionCreateRequest.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/SubscriptionCreateRequest.java
@@ -1,0 +1,15 @@
+package com.spotify.google.cloud.pubsub.client;
+
+import io.norberg.automatter.AutoMatter;
+import java.util.Optional;
+
+@AutoMatter
+public interface SubscriptionCreateRequest {
+
+  String topic();
+
+  Optional<PushConfig> pushConfig();
+
+  Optional<Integer> ackDeadlineSeconds();
+
+}

--- a/src/test/java/com/spotify/google/cloud/pubsub/client/PubsubTest.java
+++ b/src/test/java/com/spotify/google/cloud/pubsub/client/PubsubTest.java
@@ -190,15 +190,13 @@ public class PubsubTest {
     assertThat(future.operation(), is("create topic"));
     assertThat(future.method(), is("PUT"));
     assertThat(future.uri(), is(server.getUrl(expectedPath).toString()));
-    assertThat(future.payloadSize(), is(greaterThan(0L)));
+    assertThat(future.payloadSize(), is(0L));
 
     final RecordedRequest request = server.takeRequest(10, SECONDS);
 
     assertThat(request.getMethod(), is("PUT"));
     assertThat(request.getPath(), is(expectedPath));
-    assertThat(request.getHeader(CONTENT_ENCODING), is("gzip"));
-    assertThat(request.getHeader(CONTENT_LENGTH), is(String.valueOf(future.payloadSize())));
-    assertThat(request.getHeader(CONTENT_TYPE), is("application/json; charset=UTF-8"));
+    assertThat(request.getHeader(CONTENT_LENGTH), is(String.valueOf(0)));
     assertRequestHeaders(request);
 
     final Topic response = Topic.of(PROJECT, TOPIC_1);


### PR DESCRIPTION
It seems that the google pubsub emulator complains about redundant subscription/publisher names on creation (as they're present in both the payload and the post URL).

I've opened a ticket with google about fixing this on their end but they seem unwilling to do so:
https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2199

Here's a sample project that helps reproduce the issue that's being addressed here:
https://github.com/bilisie/pubsub-emulator-issue

I've ran the integration tests against prod APIs and I've also tested the code against the emulator.