### PR TITLE
allow null data - valid if at least one attribute exists

### DIFF
--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Message.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Message.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import io.norberg.automatter.AutoMatter;
+import javax.annotation.Nullable;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -35,6 +36,7 @@ public interface Message {
 
   CharMatcher BASE64_MATCHER = CharMatcher.anyOf("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=");
 
+  @Nullable
   String data();
 
   Map<String, String> attributes();


### PR DESCRIPTION
This should be enough to enable deserializing messages that omit the data field, which appears to be valid if there's at least one attribute set.
I don't really have the insight at present into the ways this client is used to send events to say whether or not it needs to validate that one of those two is set before building the message.