### PR TITLE
Add minimum support for labels

### DIFF
--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Subscription.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Subscription.java
@@ -42,6 +42,7 @@ import static com.spotify.google.cloud.pubsub.client.Topic.canonicalTopic;
 import static com.spotify.google.cloud.pubsub.client.Topic.validateCanonicalTopic;
 
 import io.norberg.automatter.AutoMatter;
+import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
@@ -56,6 +57,8 @@ public interface Subscription {
   String name();
 
   String topic();
+
+  Optional<Map<String, String>> labels();
 
   Optional<PushConfig> pushConfig();
 

--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Topic.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Topic.java
@@ -36,6 +36,8 @@
 
 package com.spotify.google.cloud.pubsub.client;
 
+import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 import io.norberg.automatter.AutoMatter;
@@ -52,6 +54,8 @@ public interface Topic {
   String TOPICS = "topics";
 
   String name();
+
+  Optional<Map<String, String>> labels();
 
   static TopicBuilder builder() {
     return new TopicBuilder();


### PR DESCRIPTION
Pubsub has added [labels](https://cloud.google.com/pubsub/docs/labels) in the latest alpha. The current version of this client crashes with a jackson UnrecognizedPropertyException in the TopicBuilder if it fetches a topic that has labels added to it. The same applies to subscriptions.

This change adds the minimum support for avoiding those crashes. It does not add support for managing labels through the client.