### PR TITLE
decrement outstanding message count on Error, reraise

### DIFF
--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Puller.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Puller.java
@@ -224,6 +224,9 @@ public class Puller implements Closeable {
               outstandingMessages.decrementAndGet();
               LOG.error("Message handler threw exception", e);
               continue;
+            } catch (Error e) {
+              outstandingMessages.decrementAndGet();
+              throw e;
             }
 
             if (handlerFuture == null) {


### PR DESCRIPTION
Not everything that can go wrong is an Exception instance - we ran into StackOverflowError's coming out of a Cassandra driver, just for instance, and these led to a leak in the outstandingMessages count that eventually stopped all pulling.