### PR TITLE
Import classes from direct Guava dependency

### DIFF
--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Json.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Json.java
@@ -36,7 +36,7 @@
 
 package com.spotify.google.cloud.pubsub.client;
 
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Throwables;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
+++ b/src/main/java/com/spotify/google/cloud/pubsub/client/Pubsub.java
@@ -64,7 +64,7 @@ import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.ByteStreams;
 import com.ning.http.client.AsyncHandler;

--- a/src/test/java/com/spotify/google/cloud/pubsub/client/integration/PubsubIT.java
+++ b/src/test/java/com/spotify/google/cloud/pubsub/client/integration/PubsubIT.java
@@ -38,7 +38,7 @@ package com.spotify.google.cloud.pubsub.client.integration;
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.util.Utils;
-import com.google.api.client.repackaged.com.google.common.base.Strings;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.BaseEncoding;
 import com.google.common.util.concurrent.Futures;

--- a/src/test/java/com/spotify/google/cloud/pubsub/client/integration/Util.java
+++ b/src/test/java/com/spotify/google/cloud/pubsub/client/integration/Util.java
@@ -36,7 +36,7 @@
 
 package com.spotify.google.cloud.pubsub.client.integration;
 
-import com.google.api.client.repackaged.com.google.common.base.Throwables;
+import com.google.common.base.Throwables;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;


### PR DESCRIPTION
This change updates some Guava class imports, in order to have them reference the classes from the project's Guava dependency, instead of the repackaged version the `google-http-client` provides.